### PR TITLE
adding edit button with reference to correct repo

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -182,6 +182,7 @@ html_theme_options = {
     "twitter_url": "https://twitter.com/openephys",
     "external_links": [{"name": "Open Ephys", "url": "https://open-ephys.org"},],
     "navigation_with_keys": True,
+    "use_edit_page_button": True,
     # 'search_bar_position' : "navbar",
     #'canonical_url': '',
     #'analytics_id': '',
@@ -201,7 +202,7 @@ html_favicon = "_static/images/favicon.png"
 
 html_context = {
     "github_user": "open-ephys",
-    "github_repo": "doc-template",
+    "github_repo": "acq-board-docs",
     "github_version": "master",
     "doc_path": "source",
     "css_files": ["_static/theme_overrides.css",],


### PR DESCRIPTION
Added `"use_edit_page_button": True` to `html_theme_options` dict to enable "Edit this Page" button on this repo's docs.  Also changed `html_context` dict so that the `"github_repo"` key has correct corresponding value. 

This is in reference to issue #11 