### PR TITLE
Commutator inclusion

### DIFF
--- a/source/Hardware-Guide/Headstages.rst
+++ b/source/Hardware-Guide/Headstages.rst
@@ -95,8 +95,8 @@ calibrated to yield precise acceleration per `this application note  <https://in
 
 .. _3dcap:
 
-3D capabilities
-----------------
+Inertial Measurement Unit (IMU)
+--------------------------------------
 
 Our 3D capable headstages are unique in that they can accurately monitor absolute head orientation thanks to an embedded 9-axis inertial measurement unit (IMU). This technology senses rotational movements (pitch, yaw, and roll) which can be used to correlate neural activity with behavioral states.
 

--- a/source/User-Manual/Quickstart-guide.rst
+++ b/source/User-Manual/Quickstart-guide.rst
@@ -45,7 +45,7 @@ The I/O ports on the Acquisition Board are as follows:
     :width: 70%
     :align: center
 
-.. note:: Other external hardware interfacing with the acquisition system can be directly connected to the PC for operation. Follow the connection guide for the specific piece of hardware. In the case of our SPI commutator, connect it to USB and connect the two SPI cables. You can find more information in its `connection guide <https://open-ephys.github.io/commutator-docs/index.html>`_.
+.. note:: Other external hardware interfacing with the acquisition system can be directly connected to the PC for operation. Follow the connection guide for the specific piece of hardware. In the case of our SPI commutator, connect it to USB and connect the two SPI cables. You can find more information in its `connection guide <https://open-ephys.github.io/commutator-docs/user-guide/mount-connect.html>`_.
 
 Grounding your system
 -------------------------------------------

--- a/source/User-Manual/Quickstart-guide.rst
+++ b/source/User-Manual/Quickstart-guide.rst
@@ -95,7 +95,7 @@ This section provides the basic steps needed in the Open Ephys GUI to get starte
   
    - A `Record Node <https://open-ephys.github.io/gui-docs/User-Manual/Plugins/Record-Node.html>`_
   
-   .. - (optional) An OE Commutator processor 
+   - (optional) A `Commutator Control processor <https://open-ephys.github.io/gui-docs/User-Manual/Plugins/Commutator-Control.html>`_ (downloaded using the Plugin Installer) to use the Open Ephys torque-free SPI Commutator
 
 3. Click the Play button to start data acquisition. Click Record to record.
    

--- a/source/User-Manual/Quickstart-guide.rst
+++ b/source/User-Manual/Quickstart-guide.rst
@@ -45,7 +45,7 @@ The I/O ports on the Acquisition Board are as follows:
     :width: 70%
     :align: center
 
-.. note:: Other external hardware interfacing with the acquisition system can be directly connected to the PC for operation. Follow the connection guide for the specific piece of hardware. In the case of our SPI commutator, connect it to USB and connect the two SPI cables. You can find more information in its `connection guide <https://open-ephys.github.io/commutator-docs/user-guide/mount-connect.html>`_.
+.. note:: Other external hardware interfacing with the acquisition system can be directly connected to the PC for operation. Follow the connection guide for the specific piece of hardware. In the case of our SPI commutator, connect it to USB and connect the two SPI cables. You can find more information in its `connection guide <https://open-ephys.github.io/commutator-docs/user-guide/mount-connect.html#connecting>`_.
 
 Grounding your system
 -------------------------------------------


### PR DESCRIPTION
Three short changes @cjsha to merge after the gui plugin docs are done.

- mentioned the commutator explicitly in the Quickstart GUI section. This is until we can make an actual tutorial as per https://github.com/open-ephys/acq-board-docs/issues/32, since it relies on users knowing much about the GUI than what the line says. My original intent with this section was that it really is plug-and-play, but since the commutator control needs some settings then it isn't.
-  the commutator control link is broken, needs merging its docs first https://github.com/open-ephys/gui-docs/pull/57.
- the commutator connection link could be updated to actually point to the tab (don't know if this is possible, but cjsha is looking into it.
- I changed the 3D capabilities title to IMU because that is how the 3D capable headstages appear in the headstage port slots of the acquisition board GUI plugin . We had branded these headstages as 3D to easily refer to their use instead of the sensor, but in actual fact all of our UI across the board mentions sensors/channels by hardware name (aux, adc, ttl, etc.), however foreign it might be for a newbie.